### PR TITLE
Remove double-array in update() method

### DIFF
--- a/src/Models/Servers/Server.php
+++ b/src/Models/Servers/Server.php
@@ -521,9 +521,7 @@ class Server extends Model
     public function update(array $data)
     {
         $response = $this->httpClient->put($this->replaceServerIdInUri('servers/{id}'), [
-            'json' => [
-                $data
-            ],
+            'json' => $data
         ]);
         if (!HetznerAPIClient::hasError($response)) {
             return APIResponse::create([


### PR DESCRIPTION
Calling the update method always returned the error: "invalid input: root must be an object"

This change fixes that.