### PR TITLE
Bugfix for floating ip description which can be null. 

### DIFF
--- a/src/Models/FloatingIps/FloatingIp.php
+++ b/src/Models/FloatingIps/FloatingIp.php
@@ -30,7 +30,7 @@ class FloatingIp extends Model implements Resource
     public $name;
 
     /**
-     * @var string
+     * @var string|null
      */
     public $description;
 
@@ -95,7 +95,7 @@ class FloatingIp extends Model implements Resource
      */
     public function __construct(
         int $id,
-        string $description,
+        ?string $description,
         string $ip,
         string $type,
         $server,

--- a/src/Models/FloatingIps/FloatingIp.php
+++ b/src/Models/FloatingIps/FloatingIp.php
@@ -81,7 +81,7 @@ class FloatingIp extends Model implements Resource
      * FloatingIp constructor.
      *
      * @param int $id
-     * @param string $description
+     * @param string|null $description
      * @param string $ip
      * @param string $type
      * @param int $server
@@ -95,7 +95,7 @@ class FloatingIp extends Model implements Resource
      */
     public function __construct(
         int $id,
-        ?string $description,
+        $description,
         string $ip,
         string $type,
         $server,


### PR DESCRIPTION
This caused an TypeError: Argument 2 passed to FloatingIp::__construct() must be of the type string, null given.

This fix resolves that issue.