### PR TITLE
Fix: apparently name can be "null"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master (XX.XX.XXXX)
 * Feature: Allow creation of Servers with Networks
+* Bugfix: The name of ISOs is not set on private ISOs, use the ID instead
 
 ## 2.1.0 (04.05.2020)
 * Bugfix: Fix wrong Guzzle Client Type on Server, Volume and FloatingIp Model.

--- a/src/Models/ISOs/ISO.php
+++ b/src/Models/ISOs/ISO.php
@@ -36,7 +36,7 @@ class ISO extends Model implements Resource
      * @param string $description
      * @param string $type
      */
-    public function __construct(int $id, string $name, string $description = null, string $type = null)
+    public function __construct(int $id, string $name = null, string $description = null, string $type = null)
     {
         $this->id = $id;
         $this->name = $name;

--- a/src/Models/Servers/Server.php
+++ b/src/Models/Servers/Server.php
@@ -447,7 +447,7 @@ class Server extends Model implements Resource
     {
         $response = $this->httpClient->post($this->replaceServerIdInUri('servers/{id}/actions/attach_iso'), [
             'json' => [
-                'iso' => $iso->id,
+                'iso' => $iso->name == null ? $iso->id: $iso->name,
             ],
         ]);
         if (! HetznerAPIClient::hasError($response)) {

--- a/src/Models/Servers/Server.php
+++ b/src/Models/Servers/Server.php
@@ -447,7 +447,7 @@ class Server extends Model implements Resource
     {
         $response = $this->httpClient->post($this->replaceServerIdInUri('servers/{id}/actions/attach_iso'), [
             'json' => [
-                'iso' => $iso->name,
+                'iso' => $iso->id,
             ],
         ]);
         if (! HetznerAPIClient::hasError($response)) {

--- a/src/Models/Servers/Server.php
+++ b/src/Models/Servers/Server.php
@@ -447,7 +447,7 @@ class Server extends Model implements Resource
     {
         $response = $this->httpClient->post($this->replaceServerIdInUri('servers/{id}/actions/attach_iso'), [
             'json' => [
-                'iso' => $iso->name == null ? $iso->id: $iso->name,
+                'iso' => $iso->name == null ? $iso->id : $iso->name,
             ],
         ]);
         if (! HetznerAPIClient::hasError($response)) {


### PR DESCRIPTION
Hetzner support added an ISO for me, but I can't pull it up using your code because the name is "null". Not sure if this is a "bug" in your code, or if it's how they added my ISO in and a bug on their end. But adding `= null` fixes it. ;-)