### PR TITLE
change test classes prefix namespace to LKDev\Tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "Tests\\": "tests/"
+      "LKDev\\Tests\\": "tests/"
     }
   },
   "scripts": {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,7 +6,7 @@
  * Time: 14:13.
  */
 
-namespace Tests;
+namespace LKDev\Tests;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;

--- a/tests/Unit/ApiResponseTest.php
+++ b/tests/Unit/ApiResponseTest.php
@@ -6,7 +6,7 @@
  * Time: 14:35.
  */
 
-namespace Tests\Unit;
+namespace LKDev\Tests\Unit;
 
 use LKDev\HetznerCloud\APIResponse;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/BasicClientTest.php
+++ b/tests/Unit/BasicClientTest.php
@@ -6,7 +6,7 @@
  * Time: 20:40.
  */
 
-namespace Tests\Unit;
+namespace LKDev\Tests\Unit;
 
 use GuzzleHttp\Client;
 use LKDev\HetznerCloud\HetznerAPIClient;
@@ -22,7 +22,7 @@ use LKDev\HetznerCloud\Models\Servers\Servers;
 use LKDev\HetznerCloud\Models\Servers\Types\ServerTypes;
 use LKDev\HetznerCloud\Models\SSHKeys\SSHKeys;
 use LKDev\HetznerCloud\Models\Volumes\Volumes;
-use Tests\TestCase;
+use LKDev\Tests\TestCase;
 
 /**
  * Class BasicClientTest.

--- a/tests/Unit/Models/Actions/ActionsTest.php
+++ b/tests/Unit/Models/Actions/ActionsTest.php
@@ -6,11 +6,11 @@
  * Time: 18:31.
  */
 
-namespace Tests\Unit\Models\Actions;
+namespace LKDev\Tests\Unit\Models\Actions;
 
 use GuzzleHttp\Psr7\Response;
 use LKDev\HetznerCloud\Models\Actions\Actions;
-use Tests\TestCase;
+use LKDev\Tests\TestCase;
 
 class ActionsTest extends TestCase
 {

--- a/tests/Unit/Models/Certificates/CertificatesTest.php
+++ b/tests/Unit/Models/Certificates/CertificatesTest.php
@@ -6,11 +6,11 @@
  * Time: 18:31.
  */
 
-namespace Tests\Unit\Models\Certificates;
+namespace LKDev\Tests\Unit\Models\Certificates;
 
 use GuzzleHttp\Psr7\Response;
 use LKDev\HetznerCloud\Models\Certificates\Certificates;
-use Tests\TestCase;
+use LKDev\Tests\TestCase;
 
 class CertificatesTest extends TestCase
 {

--- a/tests/Unit/Models/Datacenters/DatacentersTest.php
+++ b/tests/Unit/Models/Datacenters/DatacentersTest.php
@@ -6,11 +6,11 @@
  * Time: 18:31.
  */
 
-namespace Tests\Unit\Models\Datacenters;
+namespace LKDev\Tests\Unit\Models\Datacenters;
 
 use GuzzleHttp\Psr7\Response;
 use LKDev\HetznerCloud\Models\Datacenters\Datacenters;
-use Tests\TestCase;
+use LKDev\Tests\TestCase;
 
 class DatacentersTest extends TestCase
 {

--- a/tests/Unit/Models/Firewalls/FirewallTest.php
+++ b/tests/Unit/Models/Firewalls/FirewallTest.php
@@ -6,7 +6,7 @@
  * Time: 07:58.
  */
 
-namespace Tests\Unit\Models\Firewalls;
+namespace LKDev\Tests\Unit\Models\Firewalls;
 
 use GuzzleHttp\Psr7\Response;
 use LKDev\HetznerCloud\Models\Firewalls\Firewall;
@@ -14,7 +14,7 @@ use LKDev\HetznerCloud\Models\Firewalls\FirewallResource;
 use LKDev\HetznerCloud\Models\Firewalls\FirewallRule;
 use LKDev\HetznerCloud\Models\Firewalls\Firewalls;
 use LKDev\HetznerCloud\Models\Servers\Server;
-use Tests\TestCase;
+use LKDev\Tests\TestCase;
 
 /**
  * Class FloatingIpTest.

--- a/tests/Unit/Models/Firewalls/FirewallsTest.php
+++ b/tests/Unit/Models/Firewalls/FirewallsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\Models\Firewalls;
+namespace LKDev\Tests\Unit\Models\Firewalls;
 
 use GuzzleHttp\Psr7\Response;
 use LKDev\HetznerCloud\APIResponse;
@@ -9,7 +9,7 @@ use LKDev\HetznerCloud\Models\Firewalls\FirewallResource;
 use LKDev\HetznerCloud\Models\Firewalls\FirewallRule;
 use LKDev\HetznerCloud\Models\Firewalls\Firewalls;
 use LKDev\HetznerCloud\Models\Servers\Server;
-use Tests\TestCase;
+use LKDev\Tests\TestCase;
 
 /**
  * Class FirewallsTest.

--- a/tests/Unit/Models/FloatingIPs/FloatingIPsTest.php
+++ b/tests/Unit/Models/FloatingIPs/FloatingIPsTest.php
@@ -6,13 +6,13 @@
  * Time: 18:31.
  */
 
-namespace Tests\Unit\Models\FloatingIPs;
+namespace LKDev\Tests\Unit\Models\FloatingIPs;
 
 use GuzzleHttp\Psr7\Response;
 use LKDev\HetznerCloud\Models\FloatingIps\FloatingIps;
 use LKDev\HetznerCloud\Models\Locations\Location;
 use LKDev\HetznerCloud\Models\Servers\Server;
-use Tests\TestCase;
+use LKDev\Tests\TestCase;
 
 class FloatingIPsTest extends TestCase
 {

--- a/tests/Unit/Models/FloatingIPs/FloatingIpTest.php
+++ b/tests/Unit/Models/FloatingIPs/FloatingIpTest.php
@@ -6,13 +6,13 @@
  * Time: 07:58.
  */
 
-namespace Tests\Unit\Models\FloatingIPs;
+namespace LKDev\Tests\Unit\Models\FloatingIPs;
 
 use GuzzleHttp\Psr7\Response;
 use LKDev\HetznerCloud\Models\FloatingIps\FloatingIp;
 use LKDev\HetznerCloud\Models\FloatingIps\FloatingIps;
 use LKDev\HetznerCloud\Models\Servers\Server;
-use Tests\TestCase;
+use LKDev\Tests\TestCase;
 
 /**
  * Class FloatingIpTest.

--- a/tests/Unit/Models/ISO/ISOsTest.php
+++ b/tests/Unit/Models/ISO/ISOsTest.php
@@ -6,11 +6,11 @@
  * Time: 18:31.
  */
 
-namespace Tests\Unit\ISO;
+namespace LKDev\Tests\Unit\ISO;
 
 use GuzzleHttp\Psr7\Response;
 use LKDev\HetznerCloud\Models\ISOs\ISOs;
-use Tests\TestCase;
+use LKDev\Tests\TestCase;
 
 class ISOsTest extends TestCase
 {

--- a/tests/Unit/Models/Images/ImagesTest.php
+++ b/tests/Unit/Models/Images/ImagesTest.php
@@ -6,11 +6,11 @@
  * Time: 18:31.
  */
 
-namespace Tests\Unit\Models;
+namespace LKDev\Tests\Unit\Models;
 
 use GuzzleHttp\Psr7\Response;
 use LKDev\HetznerCloud\Models\Images\Images;
-use Tests\TestCase;
+use LKDev\Tests\TestCase;
 
 class ImagesTest extends TestCase
 {

--- a/tests/Unit/Models/Locations/LocationsTest.php
+++ b/tests/Unit/Models/Locations/LocationsTest.php
@@ -6,11 +6,11 @@
  * Time: 18:31.
  */
 
-namespace Tests\Unit\Models;
+namespace LKDev\Tests\Unit\Models;
 
 use GuzzleHttp\Psr7\Response;
 use LKDev\HetznerCloud\Models\Locations\Locations;
-use Tests\TestCase;
+use LKDev\Tests\TestCase;
 
 class LocationsTest extends TestCase
 {

--- a/tests/Unit/Models/Networks/NetworkTest.php
+++ b/tests/Unit/Models/Networks/NetworkTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Tests\Unit\Models\Networks;
+namespace LKDev\Tests\Unit\Models\Networks;
 
 use GuzzleHttp\Psr7\Response;
 use LKDev\HetznerCloud\Models\Networks\Network;
 use LKDev\HetznerCloud\Models\Networks\Networks;
 use LKDev\HetznerCloud\Models\Networks\Route;
 use LKDev\HetznerCloud\Models\Networks\Subnet;
-use Tests\TestCase;
+use LKDev\Tests\TestCase;
 
 class NetworkTest extends TestCase
 {

--- a/tests/Unit/Models/Networks/NetworksTest.php
+++ b/tests/Unit/Models/Networks/NetworksTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\Models\Networks;
+namespace LKDev\Tests\Unit\Models\Networks;
 
 use GuzzleHttp\Psr7\Response;
 use LKDev\HetznerCloud\APIResponse;
@@ -10,7 +10,7 @@ use LKDev\HetznerCloud\Models\Networks\Route;
 use LKDev\HetznerCloud\Models\Networks\Subnet;
 use LKDev\HetznerCloud\Models\Protection;
 use LKDev\HetznerCloud\Models\Servers\Server;
-use Tests\TestCase;
+use LKDev\Tests\TestCase;
 
 /**
  * Class NetworksTest.

--- a/tests/Unit/Models/Pricing/PricingTest.php
+++ b/tests/Unit/Models/Pricing/PricingTest.php
@@ -6,11 +6,11 @@
  * Time: 18:31.
  */
 
-namespace Tests\Unit\Pricing;
+namespace LKDev\Tests\Unit\Pricing;
 
 use GuzzleHttp\Psr7\Response;
 use LKDev\HetznerCloud\Models\Prices\Prices;
-use Tests\TestCase;
+use LKDev\Tests\TestCase;
 
 class PricingTest extends TestCase
 {

--- a/tests/Unit/Models/SSHKeys/SSHKeysTest.php
+++ b/tests/Unit/Models/SSHKeys/SSHKeysTest.php
@@ -6,11 +6,11 @@
  * Time: 18:31.
  */
 
-namespace Tests\Unit\Models\SSHKeys;
+namespace LKDev\Tests\Unit\Models\SSHKeys;
 
 use GuzzleHttp\Psr7\Response;
 use LKDev\HetznerCloud\Models\SSHKeys\SSHKeys;
-use Tests\TestCase;
+use LKDev\Tests\TestCase;
 
 class SSHKeysTest extends TestCase
 {

--- a/tests/Unit/Models/ServerTypes/ServerTypesTest.php
+++ b/tests/Unit/Models/ServerTypes/ServerTypesTest.php
@@ -6,11 +6,11 @@
  * Time: 18:31.
  */
 
-namespace Tests\Unit\Models\ServerTypes;
+namespace LKDev\Tests\Unit\Models\ServerTypes;
 
 use GuzzleHttp\Psr7\Response;
 use LKDev\HetznerCloud\Models\Servers\Types\ServerTypes;
-use Tests\TestCase;
+use LKDev\Tests\TestCase;
 
 class ServerTypesTest extends TestCase
 {

--- a/tests/Unit/Models/Servers/ServerTest.php
+++ b/tests/Unit/Models/Servers/ServerTest.php
@@ -6,7 +6,7 @@
  * Time: 19:51.
  */
 
-namespace Tests\Unit\Models\Servers;
+namespace LKDev\Tests\Unit\Models\Servers;
 
 use GuzzleHttp\Psr7\Response;
 use LKDev\HetznerCloud\Models\Images\Image;
@@ -15,7 +15,7 @@ use LKDev\HetznerCloud\Models\Networks\Network;
 use LKDev\HetznerCloud\Models\Servers\Server;
 use LKDev\HetznerCloud\Models\Servers\Servers;
 use LKDev\HetznerCloud\Models\Servers\Types\ServerType;
-use Tests\TestCase;
+use LKDev\Tests\TestCase;
 
 class ServerTest extends TestCase
 {

--- a/tests/Unit/Models/Servers/ServersTest.php
+++ b/tests/Unit/Models/Servers/ServersTest.php
@@ -6,11 +6,11 @@
  * Time: 18:31.
  */
 
-namespace Tests\Integration\Servers;
+namespace LKDev\Tests\Integration\Servers;
 
 use GuzzleHttp\Psr7\Response;
 use LKDev\HetznerCloud\Models\Servers\Servers;
-use Tests\TestCase;
+use LKDev\Tests\TestCase;
 
 class ServersTest extends TestCase
 {

--- a/tests/Unit/Models/Volumes/VolumeTest.php
+++ b/tests/Unit/Models/Volumes/VolumeTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Tests\Unit\Models\Volumes;
+namespace LKDev\Tests\Unit\Models\Volumes;
 
 use GuzzleHttp\Psr7\Response;
 use LKDev\HetznerCloud\Models\Servers\Server;
 use LKDev\HetznerCloud\Models\Volumes\Volume;
 use LKDev\HetznerCloud\Models\Volumes\Volumes;
-use Tests\TestCase;
+use LKDev\Tests\TestCase;
 
 class VolumeTest extends TestCase
 {

--- a/tests/Unit/Models/Volumes/VolumesTest.php
+++ b/tests/Unit/Models/Volumes/VolumesTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Tests\Unit\Models\Volumes;
+namespace LKDev\Tests\Unit\Models\Volumes;
 
 use GuzzleHttp\Psr7\Response;
 use LKDev\HetznerCloud\Models\Locations\Location;
 use LKDev\HetznerCloud\Models\Volumes\Volumes;
-use Tests\TestCase;
+use LKDev\Tests\TestCase;
 
 class VolumesTest extends TestCase
 {

--- a/tests/Unit/RequestOptsTest.php
+++ b/tests/Unit/RequestOptsTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Tests\Unit;
+namespace LKDev\Tests\Unit;
 
 use LKDev\HetznerCloud\RequestOpts;
-use Tests\TestCase;
+use LKDev\Tests\TestCase;
 
 class RequestOptsTest extends TestCase
 {


### PR DESCRIPTION
The  namespace `Tests` is used by Laravel framework as well, when using this package in a Laravel project, it conflicts with Laravel tests, hence I changed the namespace to `LKDev\Tests`.
