### PR TITLE
Keep Hetzner's snake_case for properties

### DIFF
--- a/src/Models/Datacenters/Datacenter.php
+++ b/src/Models/Datacenters/Datacenter.php
@@ -38,6 +38,11 @@ class Datacenter extends Model implements Resource
     /**
      * @var array
      */
+    public $server_types;
+    /**
+     * @var array
+     * @deprecated Use $server_types instead
+     */
     public $serverTypes;
 
     /**
@@ -60,6 +65,7 @@ class Datacenter extends Model implements Resource
         $this->name = $name;
         $this->description = $description;
         $this->location = $location;
+        $this->server_types = $server_types;
         $this->serverTypes = $server_types;
         parent::__construct();
     }

--- a/src/Models/Firewalls/Firewall.php
+++ b/src/Models/Firewalls/Firewall.php
@@ -46,10 +46,15 @@ class Firewall extends Model implements Resource
     /**
      * @var FirewallResource[]
      */
+    public $applied_to;
+    /**
+     * @var FirewallResource[]
+     * @deprecated Use $applied_to instead
+     */
     public $appliedTo;
 
     /**
-     * FloatingIp constructor.
+     * Firewall constructor.
      *
      * @param int $id
      * @param string $name
@@ -72,6 +77,7 @@ class Firewall extends Model implements Resource
         $this->created = $created;
         $this->name = $name;
         $this->rules = $rules;
+        $this->applied_to = $appliedTo;
         $this->appliedTo = $appliedTo;
         parent::__construct();
     }

--- a/src/Models/FloatingIps/FloatingIp.php
+++ b/src/Models/FloatingIps/FloatingIp.php
@@ -55,10 +55,20 @@ class FloatingIp extends Model implements Resource
     /**
      * @var array
      */
+    public $dns_ptr;
+    /**
+     * @var array
+     * @deprecated Use $dns_ptr instead
+     */
     public $dnsPtr;
 
     /**
      * @var \LKDev\HetznerCloud\Models\Locations\Location
+     */
+    public $home_location;
+    /**
+     * @var \LKDev\HetznerCloud\Models\Locations\Location
+     * @deprecated Use $home_location instead
      */
     public $homeLocation;
 
@@ -112,7 +122,9 @@ class FloatingIp extends Model implements Resource
         $this->ip = $ip;
         $this->type = $type;
         $this->server = $server;
+        $this->dns_ptr = $dnsPtr;
         $this->dnsPtr = $dnsPtr;
+        $this->home_location = $homeLocation;
         $this->homeLocation = $homeLocation;
         $this->blocked = $blocked;
         $this->protection = $protection;

--- a/src/Models/Images/Image.php
+++ b/src/Models/Images/Image.php
@@ -60,25 +60,50 @@ class Image extends Model implements Resource
     /**
      * @var \LKDev\HetznerCloud\Models\Servers\Server
      */
+    public $created_from;
+    /**
+     * @var \LKDev\HetznerCloud\Models\Servers\Server
+     * @deprecated Use $created_from instead
+     */
     public $createdFrom;
 
     /**
      * @var int
+     */
+    public $bound_to;
+    /**
+     * @var int
+     * @deprecated Use $bound_to instead
      */
     public $boundTo;
 
     /**
      * @var string
      */
+    public $os_flavor;
+    /**
+     * @var string
+     * @deprecated Use $os_flavor instead
+     */
     public $osFlavor;
 
     /**
      * @var string
      */
+    public $os_version;
+    /**
+     * @var string
+     * @deprecated Use $os_version instead
+     */
     public $osVersion;
 
     /**
      * @var bool
+     */
+    public $rapid_deploy;
+    /**
+     * @var bool
+     * @deprecated Use $rapid_deploy instead
      */
     public $rapidDeploy;
 
@@ -133,13 +158,20 @@ class Image extends Model implements Resource
         $this->status = $status;
         $this->name = $name;
         $this->description = $description;
+        $this->image_size = $imageSize;
         $this->imageSize = $imageSize;
+        $this->disk_size = $diskSize;
         $this->diskSize = $diskSize;
         $this->created = $created;
+        $this->created_from = $createdFrom;
         $this->createdFrom = $createdFrom;
+        $this->bound_to = $boundTo;
         $this->boundTo = $boundTo;
+        $this->os_flavor = $osFlavor;
         $this->osFlavor = $osFlavor;
+        $this->os_version = $osVersion;
         $this->osVersion = $osVersion;
+        $this->rapid_deploy = $rapidDeploy;
         $this->rapidDeploy = $rapidDeploy;
         $this->protection = $protection;
         $this->labels = $labels;

--- a/src/Models/Images/Image.php
+++ b/src/Models/Images/Image.php
@@ -45,10 +45,20 @@ class Image extends Model implements Resource
     /**
      * @var float
      */
+    public $image_size;
+    /**
+     * @var float
+     * @deprecated Use $image_size instead
+     */
     public $imageSize;
 
     /**
      * @var int
+     */
+    public $disk_size;
+    /**
+     * @var int
+     * @deprecated Use $disk_size instead
      */
     public $diskSize;
 

--- a/src/Models/Locations/Location.php
+++ b/src/Models/Locations/Location.php
@@ -52,6 +52,11 @@ class Location extends Model implements Resource
     /**
      * @var string
      */
+    public $network_zone;
+    /**
+     * @var string
+     * @deprecated Use $network_zone instead
+     */
     public $networkZone;
 
     /**
@@ -83,6 +88,7 @@ class Location extends Model implements Resource
         $this->city = $city;
         $this->latitude = $latitude;
         $this->longitude = $longitude;
+        $this->network_zone = $networkZone;
         $this->networkZone = $networkZone;
         parent::__construct();
     }

--- a/src/Models/Networks/Network.php
+++ b/src/Models/Networks/Network.php
@@ -20,34 +20,47 @@ class Network extends Model implements Resource
      * @var int
      */
     public $id;
+
     /**
      * @var string
      */
     public $name;
+
     /**
      * @var string
      */
+    public $ip_range;
+    /**
+     * @var string
+     * @deprecated Use $ip_range instead
+     */
     public $ipRange;
+
     /**
      * @var array
      */
     public $subnets;
+
     /**
      * @var array
      */
     public $routes;
+
     /**
      * @var array
      */
     public $servers;
+
     /**
      * @var Protection
      */
     public $protection;
+
     /**
      * @var array
      */
     public $labels;
+
     /**
      * @var string
      */
@@ -175,6 +188,7 @@ class Network extends Model implements Resource
     private function setAdditionalData($data)
     {
         $this->name = $data->name;
+        $this->ip_range = $data->ip_range;
         $this->ipRange = $data->ip_range;
         $this->subnets = Subnet::parse($data->subnets, $this->httpClient);
         $this->routes = Route::parse($data->routes, $this->httpClient);

--- a/src/Models/Servers/Server.php
+++ b/src/Models/Servers/Server.php
@@ -46,23 +46,30 @@ class Server extends Model implements Resource
     /**
      * @var array
      */
-    public $publicNet;
-    /**
-     * @var array
-     */
     public $public_net;
-
     /**
      * @var array
+     * @deprecated Use $public_net instead
      */
-    public $privateNet;
+    public $publicNet;
+
     /**
      * @var array
      */
     public $private_net;
+    /**
+     * @var array
+     * @deprecated Use $private_net instead
+     */
+    public $privateNet;
 
     /**
      * @var ServerType
+     */
+    public $server_type;
+    /**
+     * @var ServerType
+     * @deprecated Use $server_type instead
      */
     public $serverType;
 
@@ -84,30 +91,55 @@ class Server extends Model implements Resource
     /**
      * @var bool
      */
+    public $rescue_enabled;
+    /**
+     * @var bool
+     * @deprecated Use $rescue_enabled instead
+     */
     public $rescueEnabled;
 
     /**
      * @var bool
      */
     public $locked;
-
+    
     /**
      * @var string
+     */
+    public $backup_window;
+    /**
+     * @var string
+     * @deprecated Use $backup_window instead
      */
     public $backupWindow;
 
     /**
      * @var int
      */
+    public $outgoing_traffic;
+    /**
+     * @var int
+     * @deprecated Use $outgoing_traffic instead
+     */
     public $outgoingTraffic;
 
     /**
      * @var int
      */
+    public $ingoing_traffic;
+    /**
+     * @var int
+     * @deprecated Use $ingoing_traffic instead
+     */
     public $ingoingTraffic;
 
     /**
      * @var int
+     */
+    public $included_traffic;
+    /**
+     * @var int
+     * @deprecated Use $included_traffic instead
      */
     public $includedTraffic;
 
@@ -129,6 +161,11 @@ class Server extends Model implements Resource
     /**
      * @var int
      */
+    public $primary_disk_size;
+    /**
+     * @var int
+     * @deprecated Use $primary_disk_size instead
+     */
     public $primaryDiskSize;
 
     /**
@@ -149,24 +186,31 @@ class Server extends Model implements Resource
     {
         $this->name = $data->name;
         $this->status = $data->status ?: null;
-        $this->publicNet = $data->public_net ?: null;
         $this->public_net = $data->public_net ?: null;
-        $this->privateNet = property_exists($data, 'private_net') ? $data->private_net : [];
+        $this->publicNet = $data->public_net ?: null;
         $this->private_net = property_exists($data, 'private_net') ? $data->private_net : [];
+        $this->privateNet = property_exists($data, 'private_net') ? $data->private_net : [];
+        $this->server_type = $data->server_type ?: ServerType::parse($data->server_type);
         $this->serverType = $data->server_type ?: ServerType::parse($data->server_type);
         $this->datacenter = $data->datacenter ?: Datacenter::parse($data->datacenter);
         $this->created = $data->created;
         $this->image = $data->image ?: Image::parse($data->image);
         $this->iso = $data->iso ?: ISO::parse($data->iso);
+        $this->rescue_enabled = $data->rescue_enabled ?: null;
         $this->rescueEnabled = $data->rescue_enabled ?: null;
         $this->locked = $data->locked ?: null;
+        $this->backup_window = $data->backup_window ?: null;
         $this->backupWindow = $data->backup_window ?: null;
+        $this->outgoing_traffic = $data->outgoing_traffic ?: null;
         $this->outgoingTraffic = $data->outgoing_traffic ?: null;
+        $this->ingoing_traffic = $data->ingoing_traffic ?: null;
         $this->ingoingTraffic = $data->ingoing_traffic ?: null;
+        $this->included_traffic = $data->included_traffic ?: null;
         $this->includedTraffic = $data->included_traffic ?: null;
         $this->volumes = property_exists($data, 'volumes') ? $data->volumes : [];
         $this->protection = $data->protection ?: Protection::parse($data->protection);
         $this->labels = $data->labels;
+        $this->primary_disk_size = $data->primary_disk_size ?: null;
         $this->primaryDiskSize = $data->primary_disk_size ?: null;
 
         return $this;

--- a/src/Models/Servers/Server.php
+++ b/src/Models/Servers/Server.php
@@ -47,11 +47,20 @@ class Server extends Model implements Resource
      * @var array
      */
     public $publicNet;
+    /**
+     * @var array
+     */
+    public $public_net;
 
     /**
      * @var array
      */
     public $privateNet;
+    /**
+     * @var array
+     */
+    public $private_net;
+
     /**
      * @var ServerType
      */
@@ -140,8 +149,10 @@ class Server extends Model implements Resource
     {
         $this->name = $data->name;
         $this->status = $data->status ?: null;
+        $this->publicNet = $data->public_net ?: null;
         $this->public_net = $data->public_net ?: null;
         $this->privateNet = property_exists($data, 'private_net') ? $data->private_net : [];
+        $this->private_net = property_exists($data, 'private_net') ? $data->private_net : [];
         $this->serverType = $data->server_type ?: ServerType::parse($data->server_type);
         $this->datacenter = $data->datacenter ?: Datacenter::parse($data->datacenter);
         $this->created = $data->created;

--- a/src/Models/Servers/Server.php
+++ b/src/Models/Servers/Server.php
@@ -102,7 +102,7 @@ class Server extends Model implements Resource
      * @var bool
      */
     public $locked;
-    
+
     /**
      * @var string
      */

--- a/src/Models/Servers/Server.php
+++ b/src/Models/Servers/Server.php
@@ -140,7 +140,7 @@ class Server extends Model implements Resource
     {
         $this->name = $data->name;
         $this->status = $data->status ?: null;
-        $this->publicNet = $data->public_net ?: null;
+        $this->public_net = $data->public_net ?: null;
         $this->privateNet = property_exists($data, 'private_net') ? $data->private_net : [];
         $this->serverType = $data->server_type ?: ServerType::parse($data->server_type);
         $this->datacenter = $data->datacenter ?: Datacenter::parse($data->datacenter);


### PR DESCRIPTION
Don't you think it would be easier to just keep the properties as they're coming, to be compatible with https://docs.hetzner.cloud/#servers-get-a-server ?