### PR TITLE
Implement `Model::setHttpClient()`

### DIFF
--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -28,4 +28,13 @@ abstract class Model
     public static function parse($input)
     {
     }
+
+    /**
+     * Replaces or sets the http client.
+     * @param Client $httpClient
+     */
+    public function setHttpClient(Client $httpClient = null)
+    {
+        $this->httpClient = $httpClient;
+    }
 }


### PR DESCRIPTION
This change is necessary (for us) to strip out the `httpClient`/Guzzle from the results since we're going to cache them and it causes a lot of unnecessary wasted storage - and can't be serialized:
`Serialization of 'Closure' is not allowed`