### PR TITLE
fixes nullable port

### DIFF
--- a/src/Models/Firewalls/Firewall.php
+++ b/src/Models/Firewalls/Firewall.php
@@ -115,7 +115,7 @@ class Firewall extends Model implements Resource
         $rules = [];
 
         foreach ($input->rules as $r) {
-            $rules[] = new FirewallRule($r->direction, $r->protocol, $r->source_ips, $r->destination_ips, $r->port);
+            $rules[] = new FirewallRule($r->direction, $r->protocol, $r->source_ips, $r->destination_ips, (string) $r->port);
         }
 
         foreach ($input->applied_to as $a) {


### PR DESCRIPTION
If you created a ICMP Rule, the port is nullable.

**This change fixes:** 
_TypeError: LKDev\HetznerCloud\Models\Firewalls\FirewallRule::__construct(): Argument #5 ($port) must be of type string, null given, called in /var/www/html/vendor/lkdevelopment/hetzner-cloud-php-sdk/src/Models/Firewalls/Firewall.php on line 112 and defined in /var/www/html/vendor/lkdevelopment/hetzner-cloud-php-sdk/src/Models/Firewalls/FirewallRule.php:48_

![image](https://user-images.githubusercontent.com/5179743/136656604-f3ce1279-9086-4ac2-80e3-3448a17167c4.png)
![image](https://user-images.githubusercontent.com/5179743/136656610-4c399a85-02f7-449f-b5c1-27e7dfa9729e.png)
