### PR TITLE
Prevent API undefined property: stdClass:$server error when firewall has attached tags

### DIFF
--- a/src/Models/Firewalls/Firewall.php
+++ b/src/Models/Firewalls/Firewall.php
@@ -122,7 +122,9 @@ class Firewall extends Model implements Resource
         }
 
         foreach ($input->applied_to as $a) {
-            $appliedTo[] = new FirewallResource($a->type, new Server($a->server->id));
+            if($a->type === 'server'){
+                $appliedTo[] = new FirewallResource($a->type, new Server($a->server->id));
+            }
         }
 
         return new self($input->id, $input->name, $rules, $appliedTo, get_object_vars($input->labels), $input->created);

--- a/tests/Unit/Models/Firewalls/fixtures/firewall.json
+++ b/tests/Unit/Models/Firewalls/fixtures/firewall.json
@@ -27,6 +27,12 @@
         "server": {
           "id": 42
         }
+      },
+      {
+        "type": "label_selector",
+        "label_selector": {
+          "applied_to_resources": []
+        }
       }
     ]
   }

--- a/tests/Unit/Models/Firewalls/fixtures/firewalls.json
+++ b/tests/Unit/Models/Firewalls/fixtures/firewalls.json
@@ -28,6 +28,12 @@
           "server": {
             "id": 42
           }
+        },
+        {
+          "type": "label_selector",
+          "label_selector": {
+            "applied_to_resources": []
+          }
         }
       ]
     }


### PR DESCRIPTION
Hello this is my first PR in this project:

Before this PR following error occurred when you query a firewall with an attached label:

`Undefined property: stdClass::$server thrown in hetzner-cloud-php-sdk/src/Models/Firewalls/Firewall.php:125`

I reproduced this error by extending the **firewall.json** and **firewalls.json** fixtures with tag objects.

This error happens because the firewall model assumes that only server resources can be attached to a firewall.

This PR checks every firewall applied service and only adds it to the appliedTo array when it is a server object. This is only a workaround around this problem. In the future these tags(and their corresponding servers) should also be applied to the appliedTo array but this needs some bigger refactoring in the firewall model code. So this is only a quick fix.

Thank you for your hard work!

