### PR TITLE
BUG: Servers create Firewalls Request Option should not get json encoded

### DIFF
--- a/src/Models/Servers/Servers.php
+++ b/src/Models/Servers/Servers.php
@@ -165,7 +165,7 @@ class Servers extends Model
             $parameters['labels'] = $labels;
         }
         if (! empty($firewalls)) {
-            $parameters['firewalls'] = json_encode($firewalls);
+            $parameters['firewalls'] = $firewalls;
         }
         $response = $this->httpClient->post('servers', [
             'json' => $parameters,


### PR DESCRIPTION
The whole Request seems to be json encoded - the API throws an error if the firewall option is json encoded before