### PR TITLE
Assignee_id must be nullable

### DIFF
--- a/src/Models/PrimaryIps/PrimaryIp.php
+++ b/src/Models/PrimaryIps/PrimaryIp.php
@@ -93,7 +93,7 @@ class PrimaryIp extends Model implements Resource
      * @param  int|null  $assignee_id
      * @param  bool  $auto_delete
      */
-    public function __construct(int $id, string $name, string $created, string $ip, string $type, array $dns_ptr, bool $blocked, $protection, array $labels, $datacenter, string $assignee_type, int $assignee_id = null, bool $auto_delete)
+    public function __construct(int $id, string $name, string $created, string $ip, string $type, array $dns_ptr, bool $blocked, $protection, array $labels, $datacenter, string $assignee_type, int $assignee_id = null, bool $auto_delete=false)
     {
         $this->id = $id;
         $this->name = $name;

--- a/src/Models/PrimaryIps/PrimaryIp.php
+++ b/src/Models/PrimaryIps/PrimaryIp.php
@@ -90,10 +90,10 @@ class PrimaryIp extends Model implements Resource
      * @param  array  $labels
      * @param  array|\LKDev\HetznerCloud\Models\Datacenters\Datacenter  $datacenter
      * @param  string  $assignee_type
-     * @param  int  $assignee_id
+     * @param  int|null  $assignee_id
      * @param  bool  $auto_delete
      */
-    public function __construct(int $id, string $name, string $created, string $ip, string $type, array $dns_ptr, bool $blocked, $protection, array $labels, $datacenter, string $assignee_type, int $assignee_id, bool $auto_delete)
+    public function __construct(int $id, string $name, string $created, string $ip, string $type, array $dns_ptr, bool $blocked, $protection, array $labels, $datacenter, string $assignee_type, int $assignee_id = null, bool $auto_delete)
     {
         $this->id = $id;
         $this->name = $name;


### PR DESCRIPTION
A primary IP can be unassigned and therefore assignee_id will be null, which led to an exception.

```
<b>Fatal error</b>:  Uncaught TypeError: Argument 12 passed to LKDev\HetznerCloud\Models\PrimaryIps\PrimaryIp::__construct() must be of the type integer, null given, called in /opt/ops-ip-lister/vendor/lkdevelopment/hetzner-cloud-php-sdk/src/Models/PrimaryIps/PrimaryIp.php on line 166 and defined in /opt/ops-ip-lister/vendor/lkdevelopment/hetzner-cloud-php-sdk/src/Models/PrimaryIps/PrimaryIp.php:96
Stack trace:
#0 /opt/ops-ip-lister/vendor/lkdevelopment/hetzner-cloud-php-sdk/src/Models/PrimaryIps/PrimaryIp.php(166): LKDev\HetznerCloud\Models\PrimaryIps\PrimaryIp-&gt;__construct(0000, 'base-image', '2023-12-23T02:0...', '1.1.1.1', 'ipv4', Array, false, Object(LKDev\HetznerCloud\Models\Protection), Array, Object(LKDev\HetznerCloud\Models\Datacenters\Datacenter), 'server', NULL, false)
#1 /opt/ops-ip-lister/vendor/lkdevelopment/hetzner-cloud-php-sdk/src/Models/PrimaryIps/PrimaryIps.php(163): LKDev\HetznerCloud\Models\PrimaryIps\PrimaryIp::parse(Object(stdClass))
#2 [internal function]: LKDev\HetznerCloud\Models\PrimaryIps\Prim in <b>/opt/ops-ip-lister/vendor/lkdevelopment/hetzner-cloud-php-sdk/src/Models/PrimaryIps/PrimaryIp.php</b> on line <b>96</b><br />

```