### PR TITLE
Handle null errors in Action model instantiation

### DIFF
--- a/src/Models/Actions/Action.php
+++ b/src/Models/Actions/Action.php
@@ -148,6 +148,6 @@ class Action extends Model implements Resource
             return;
         }
 
-        return new self($input->id, $input->command, $input->progress, $input->status, $input->started, $input->finished, $input->resources, $input->error);
+        return new self($input->id, $input->command, $input->progress, $input->status, $input->started, $input->finished, $input->resources, $input->error ?? null);
     }
 }


### PR DESCRIPTION
On volume creation, error is not available in the response.

`Undefined property: stdClass::$error {"userId":1,"exception":"[object] (ErrorException(code: 0): Undefined property: stdClass::$error at /var/www/html/vendor/lkdevelopment/hetzner-cloud-php-sdk/src/Models/Actions/Action.php:153)`

Previously, the `error` property could be undefined, leading to potential issues during object creation. This update ensures that `error` defaults to `null` if not provided, enhancing the robustness of the Action model instantiation process.