### PR TITLE
Fix nullable type declarations

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e49d38d8ddf70507912bd07846b88d0c",
+    "content-hash": "66e5b8cd25ad8d8aa5afc204947a615e",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -2707,13 +2707,13 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.1|^8.0",
+        "php": "^8.1",
         "ext-json": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/src/APIException.php
+++ b/src/APIException.php
@@ -17,7 +17,7 @@ class APIException extends \Exception
      * @param  int  $code
      * @param  \Throwable|null  $previous
      */
-    public function __construct(APIResponse $response, string $message = '', int $code = 0, \Throwable $previous = null)
+    public function __construct(APIResponse $response, string $message = '', int $code = 0, ?\Throwable $previous = null)
     {
         $this->response = $response;
         parent::__construct($message, $code, $previous);

--- a/src/APIResponse.php
+++ b/src/APIResponse.php
@@ -36,7 +36,7 @@ class APIResponse
      * @param  string|null  $resource
      * @return Model|string|bool
      */
-    public function getResponsePart(string $resource = null)
+    public function getResponsePart(?string $resource = null)
     {
         return (array_key_exists($resource, $this->response)) ? $this->response[$resource] : false;
     }

--- a/src/Models/Actions/Action.php
+++ b/src/Models/Actions/Action.php
@@ -67,7 +67,7 @@ class Action extends Model implements Resource
         int $progress,
         string $status,
         string $started,
-        string $finished = null,
+        ?string $finished = null,
         $resources = null,
         $error = null
     ) {

--- a/src/Models/Actions/ActionRequestOpts.php
+++ b/src/Models/Actions/ActionRequestOpts.php
@@ -30,7 +30,7 @@ class ActionRequestOpts extends RequestOpts
      * @param  $page
      * @param  $labelSelector
      */
-    public function __construct(string $status = null, string $sort = null, int $perPage = null, int $page = null, string $labelSelector = null)
+    public function __construct(?string $status = null, ?string $sort = null, ?int $perPage = null, ?int $page = null, ?string $labelSelector = null)
     {
         parent::__construct($perPage, $page, $labelSelector);
         $this->status = $status;

--- a/src/Models/Actions/Actions.php
+++ b/src/Models/Actions/Actions.php
@@ -20,7 +20,7 @@ class Actions extends Model implements Resources
      */
     protected $actions;
 
-    public function all(RequestOpts $requestOpts = null): array
+    public function all(?RequestOpts $requestOpts = null): array
     {
         if ($requestOpts == null) {
             $requestOpts = new RequestOpts();
@@ -35,7 +35,7 @@ class Actions extends Model implements Resources
      *
      * @throws \LKDev\HetznerCloud\APIException
      */
-    public function list(RequestOpts $requestOpts = null): ?APIResponse
+    public function list(?RequestOpts $requestOpts = null): ?APIResponse
     {
         if ($requestOpts == null) {
             $requestOpts = new RequestOpts();

--- a/src/Models/Certificates/Certificate.php
+++ b/src/Models/Certificates/Certificate.php
@@ -71,7 +71,7 @@ class Certificate extends Model implements Resource
      * @param  array|null  $used_by
      * @param  array|null  $labels
      */
-    public function __construct(int $id, string $name = null, string $certificate = null, string $created = null, string $not_valid_before = null, string $not_valid_after = null, array $domain_names = null, string $fingerprint = null, $used_by = null, $labels = [])
+    public function __construct(int $id, ?string $name = null, ?string $certificate = null, ?string $created = null, ?string $not_valid_before = null, ?string $not_valid_after = null, ?array $domain_names = null, ?string $fingerprint = null, $used_by = null, $labels = [])
     {
         $this->id = $id;
         $this->name = $name;

--- a/src/Models/Certificates/CertificateRequestOpts.php
+++ b/src/Models/Certificates/CertificateRequestOpts.php
@@ -25,7 +25,7 @@ class CertificateRequestOpts extends RequestOpts
      * @param  $page
      * @param  $labelSelector
      */
-    public function __construct(string $name = null, int $perPage = null, int $page = null, string $labelSelector = null)
+    public function __construct(?string $name = null, ?int $perPage = null, ?int $page = null, ?string $labelSelector = null)
     {
         parent::__construct($perPage, $page, $labelSelector);
         $this->name = $name;

--- a/src/Models/Certificates/Certificates.php
+++ b/src/Models/Certificates/Certificates.php
@@ -72,7 +72,7 @@ class Certificates extends Model implements Resources
      *
      * @throws \LKDev\HetznerCloud\APIException
      */
-    public function all(RequestOpts $requestOpts = null): array
+    public function all(?RequestOpts $requestOpts = null): array
     {
         if ($requestOpts == null) {
             $requestOpts = new RequestOpts();
@@ -91,7 +91,7 @@ class Certificates extends Model implements Resources
      *
      * @throws \LKDev\HetznerCloud\APIException
      */
-    public function list(RequestOpts $requestOpts = null): ?APIResponse
+    public function list(?RequestOpts $requestOpts = null): ?APIResponse
     {
         if ($requestOpts == null) {
             $requestOpts = new RequestOpts();

--- a/src/Models/Contracts/Resources.php
+++ b/src/Models/Contracts/Resources.php
@@ -7,9 +7,9 @@ use LKDev\HetznerCloud\RequestOpts;
 
 interface Resources
 {
-    public function all(RequestOpts $requestOpts = null): array;
+    public function all(?RequestOpts $requestOpts = null): array;
 
-    public function list(RequestOpts $requestOpts = null): ?APIResponse;
+    public function list(?RequestOpts $requestOpts = null): ?APIResponse;
 
     public function getById(int $id);
 

--- a/src/Models/Datacenters/DatacenterRequestOpts.php
+++ b/src/Models/Datacenters/DatacenterRequestOpts.php
@@ -25,7 +25,7 @@ class DatacenterRequestOpts extends RequestOpts
      * @param  $page
      * @param  $labelSelector
      */
-    public function __construct(string $name = null, int $perPage = null, int $page = null, string $labelSelector = null)
+    public function __construct(?string $name = null, ?int $perPage = null, ?int $page = null, ?string $labelSelector = null)
     {
         parent::__construct($perPage, $page, $labelSelector);
         $this->name = $name;

--- a/src/Models/Datacenters/Datacenters.php
+++ b/src/Models/Datacenters/Datacenters.php
@@ -38,7 +38,7 @@ class Datacenters extends Model implements Resources
      *
      * @throws \LKDev\HetznerCloud\APIException
      */
-    public function all(RequestOpts $requestOpts = null): array
+    public function all(?RequestOpts $requestOpts = null): array
     {
         if ($requestOpts == null) {
             $requestOpts = new DatacenterRequestOpts();
@@ -57,7 +57,7 @@ class Datacenters extends Model implements Resources
      *
      * @throws \LKDev\HetznerCloud\APIException
      */
-    public function list(RequestOpts $requestOpts = null): ?APIResponse
+    public function list(?RequestOpts $requestOpts = null): ?APIResponse
     {
         if ($requestOpts == null) {
             $requestOpts = new DatacenterRequestOpts();

--- a/src/Models/Firewalls/FirewallRequestOpts.php
+++ b/src/Models/Firewalls/FirewallRequestOpts.php
@@ -22,7 +22,7 @@ class FirewallRequestOpts extends RequestOpts
      * @param  $page
      * @param  $labelSelector
      */
-    public function __construct(string $name = null, int $perPage = null, int $page = null, string $labelSelector = null)
+    public function __construct(?string $name = null, ?int $perPage = null, ?int $page = null, ?string $labelSelector = null)
     {
         $this->name = $name;
         parent::__construct($perPage, $page, $labelSelector);

--- a/src/Models/Firewalls/Firewalls.php
+++ b/src/Models/Firewalls/Firewalls.php
@@ -36,7 +36,7 @@ class Firewalls extends Model implements Resources
      *
      * @throws \LKDev\HetznerCloud\APIException
      */
-    public function all(RequestOpts $requestOpts = null): array
+    public function all(?RequestOpts $requestOpts = null): array
     {
         if ($requestOpts == null) {
             $requestOpts = new FirewallRequestOpts();
@@ -100,7 +100,7 @@ class Firewalls extends Model implements Resources
      *
      * @throws \LKDev\HetznerCloud\APIException
      */
-    public function list(RequestOpts $requestOpts = null): ?APIResponse
+    public function list(?RequestOpts $requestOpts = null): ?APIResponse
     {
         if ($requestOpts == null) {
             $requestOpts = new FirewallRequestOpts();

--- a/src/Models/FloatingIps/FloatingIPRequestOpts.php
+++ b/src/Models/FloatingIps/FloatingIPRequestOpts.php
@@ -23,7 +23,7 @@ class FloatingIPRequestOpts extends RequestOpts
      * @param  $page
      * @param  $labelSelector
      */
-    public function __construct(string $name = null, int $perPage = null, int $page = null, string $labelSelector = null)
+    public function __construct(?string $name = null, ?int $perPage = null, ?int $page = null, ?string $labelSelector = null)
     {
         $this->name = $name;
         parent::__construct($perPage, $page, $labelSelector);

--- a/src/Models/FloatingIps/FloatingIp.php
+++ b/src/Models/FloatingIps/FloatingIp.php
@@ -278,7 +278,7 @@ class FloatingIp extends Model implements Resource
      *
      * @throws \LKDev\HetznerCloud\APIException
      */
-    public function changeReverseDNS(string $ip, string $dnsPtr = null): ?APIResponse
+    public function changeReverseDNS(string $ip, ?string $dnsPtr = null): ?APIResponse
     {
         $response = $this->httpClient->post('floating_ips/'.$this->id.'/actions/change_dns_ptr', [
             'json' => [

--- a/src/Models/FloatingIps/FloatingIps.php
+++ b/src/Models/FloatingIps/FloatingIps.php
@@ -37,7 +37,7 @@ class FloatingIps extends Model implements Resources
      *
      * @throws \LKDev\HetznerCloud\APIException
      */
-    public function all(RequestOpts $requestOpts = null): array
+    public function all(?RequestOpts $requestOpts = null): array
     {
         if ($requestOpts == null) {
             $requestOpts = new FloatingIPRequestOpts();
@@ -56,7 +56,7 @@ class FloatingIps extends Model implements Resources
      *
      * @throws \LKDev\HetznerCloud\APIException
      */
-    public function list(RequestOpts $requestOpts = null): ?APIResponse
+    public function list(?RequestOpts $requestOpts = null): ?APIResponse
     {
         if ($requestOpts == null) {
             $requestOpts = new FloatingIPRequestOpts();
@@ -128,10 +128,10 @@ class FloatingIps extends Model implements Resources
      */
     public function create(
         string $type,
-        string $description = null,
-        Location $location = null,
-        Server $server = null,
-        string $name = null,
+        ?string $description = null,
+        ?Location $location = null,
+        ?Server $server = null,
+        ?string $name = null,
         array $labels = []
     ): ?FloatingIp {
         $parameters = [

--- a/src/Models/ISOs/ISO.php
+++ b/src/Models/ISOs/ISO.php
@@ -36,7 +36,7 @@ class ISO extends Model implements Resource
      * @param  string  $description
      * @param  string  $type
      */
-    public function __construct(int $id, string $name = null, string $description = null, string $type = null)
+    public function __construct(int $id, ?string $name = null, ?string $description = null, ?string $type = null)
     {
         $this->id = $id;
         $this->name = $name;

--- a/src/Models/ISOs/ISORequestOpts.php
+++ b/src/Models/ISOs/ISORequestOpts.php
@@ -25,7 +25,7 @@ class ISORequestOpts extends RequestOpts
      * @param  $page
      * @param  $labelSelector
      */
-    public function __construct(string $name = null, int $perPage = null, int $page = null, string $labelSelector = null)
+    public function __construct(?string $name = null, ?int $perPage = null, ?int $page = null, ?string $labelSelector = null)
     {
         parent::__construct($perPage, $page, $labelSelector);
         $this->name = $name;

--- a/src/Models/ISOs/ISOs.php
+++ b/src/Models/ISOs/ISOs.php
@@ -35,7 +35,7 @@ class ISOs extends Model implements Resources
      *
      * @throws \LKDev\HetznerCloud\APIException
      */
-    public function all(RequestOpts $requestOpts = null): array
+    public function all(?RequestOpts $requestOpts = null): array
     {
         if ($requestOpts == null) {
             $requestOpts = new ISORequestOpts();
@@ -54,7 +54,7 @@ class ISOs extends Model implements Resources
      *
      * @throws \LKDev\HetznerCloud\APIException
      */
-    public function list(RequestOpts $requestOpts = null): ?APIResponse
+    public function list(?RequestOpts $requestOpts = null): ?APIResponse
     {
         if ($requestOpts == null) {
             $requestOpts = new RequestOpts();

--- a/src/Models/Images/Image.php
+++ b/src/Models/Images/Image.php
@@ -165,20 +165,20 @@ class Image extends Model implements Resource
      */
     public function __construct(
         int $id,
-        string $type = null,
-        string $status = null,
-        string $name = null,
-        string $description = null,
-        float $imageSize = null,
-        int $diskSize = null,
-        string $created = null,
+        ?string $type = null,
+        ?string $status = null,
+        ?string $name = null,
+        ?string $description = null,
+        ?float $imageSize = null,
+        ?int $diskSize = null,
+        ?string $created = null,
         $createdFrom = null,
-        int $boundTo = null,
-        string $osFlavor = null,
-        string $osVersion = null,
-        bool $rapidDeploy = null,
-        Protection $protection = null,
-        string $architecture = null,
+        ?int $boundTo = null,
+        ?string $osFlavor = null,
+        ?string $osVersion = null,
+        ?bool $rapidDeploy = null,
+        ?Protection $protection = null,
+        ?string $architecture = null,
         array $labels = []
     ) {
         $this->id = $id;

--- a/src/Models/Images/ImageRequestOpts.php
+++ b/src/Models/Images/ImageRequestOpts.php
@@ -29,7 +29,7 @@ class ImageRequestOpts extends RequestOpts
      * @param  string|null  $labelSelector
      * @param  string|null  $architecture
      */
-    public function __construct(string $name = null, int $perPage = null, int $page = null, string $labelSelector = null, string $architecture = null)
+    public function __construct(?string $name = null, ?int $perPage = null, ?int $page = null, ?string $labelSelector = null, ?string $architecture = null)
     {
         parent::__construct($perPage, $page, $labelSelector);
         $this->name = $name;

--- a/src/Models/Images/Images.php
+++ b/src/Models/Images/Images.php
@@ -31,7 +31,7 @@ class Images extends Model implements Resources
      *
      * @throws \LKDev\HetznerCloud\APIException
      */
-    public function all(RequestOpts $requestOpts = null): array
+    public function all(?RequestOpts $requestOpts = null): array
     {
         if ($requestOpts == null) {
             $requestOpts = new ImageRequestOpts();
@@ -51,7 +51,7 @@ class Images extends Model implements Resources
      * @throws APIException
      * @throws GuzzleException
      */
-    public function list(RequestOpts $requestOpts = null): ?APIResponse
+    public function list(?RequestOpts $requestOpts = null): ?APIResponse
     {
         if ($requestOpts == null) {
             $requestOpts = new ImageRequestOpts();
@@ -100,7 +100,7 @@ class Images extends Model implements Resources
      *
      * @throws APIException
      */
-    public function getByName(string $name, string $architecture = null): ?Image
+    public function getByName(string $name, ?string $architecture = null): ?Image
     {
         $images = $this->list(new ImageRequestOpts($name, null, null, null, $architecture));
 

--- a/src/Models/LoadBalancerTypes/LoadBalancerTypeRequestOpts.php
+++ b/src/Models/LoadBalancerTypes/LoadBalancerTypeRequestOpts.php
@@ -19,7 +19,7 @@ class LoadBalancerTypeRequestOpts extends RequestOpts
      * @param  $page
      * @param  $labelSelector
      */
-    public function __construct(string $name = null, int $perPage = null, int $page = null, string $labelSelector = null)
+    public function __construct(?string $name = null, ?int $perPage = null, ?int $page = null, ?string $labelSelector = null)
     {
         parent::__construct($perPage, $page, $labelSelector);
         $this->name = $name;

--- a/src/Models/LoadBalancerTypes/LoadBalancerTypes.php
+++ b/src/Models/LoadBalancerTypes/LoadBalancerTypes.php
@@ -29,7 +29,7 @@ class LoadBalancerTypes extends Model implements Resources
      *
      * @throws \LKDev\HetznerCloud\APIException
      */
-    public function all(RequestOpts $requestOpts = null): array
+    public function all(?RequestOpts $requestOpts = null): array
     {
         if ($requestOpts == null) {
             $requestOpts = new LoadBalancerTypeRequestOpts();
@@ -48,7 +48,7 @@ class LoadBalancerTypes extends Model implements Resources
      *
      * @throws \LKDev\HetznerCloud\APIException
      */
-    public function list(RequestOpts $requestOpts = null): ?APIResponse
+    public function list(?RequestOpts $requestOpts = null): ?APIResponse
     {
         if ($requestOpts == null) {
             $requestOpts = new LoadBalancerTypeRequestOpts();

--- a/src/Models/LoadBalancers/LoadBalancer.php
+++ b/src/Models/LoadBalancers/LoadBalancer.php
@@ -108,7 +108,7 @@ class LoadBalancer extends Model implements Resource
      * @param  int|null  $ingoing_traffic
      * @param  int|null  $outgoing_traffic
      */
-    public function __construct(int $id, string $name, LoadBalancerAlgorithm $algorithm, string $created, int $included_traffic, array $labels, LoadBalancerType $loadBalancerType, Location $location, array $private_net, $protection, $public_net, array $services, array $targets, int $ingoing_traffic = null, int $outgoing_traffic = null)
+    public function __construct(int $id, string $name, LoadBalancerAlgorithm $algorithm, string $created, int $included_traffic, array $labels, LoadBalancerType $loadBalancerType, Location $location, array $private_net, $protection, $public_net, array $services, array $targets, ?int $ingoing_traffic = null, ?int $outgoing_traffic = null)
     {
         $this->id = $id;
         $this->name = $name;
@@ -193,7 +193,7 @@ class LoadBalancer extends Model implements Resource
      * @throws APIException
      * @throws GuzzleException
      */
-    public function addService(string $destinationPort, LoadBalancerHealthCheck $healthCheck, int $listenPort, string $protocol, string $proxyprotocol, LoadBalancerServiceHttp $http = null): ?APIResponse
+    public function addService(string $destinationPort, LoadBalancerHealthCheck $healthCheck, int $listenPort, string $protocol, string $proxyprotocol, ?LoadBalancerServiceHttp $http = null): ?APIResponse
     {
         $payload = [
             'destination_port' => $destinationPort,
@@ -232,7 +232,7 @@ class LoadBalancer extends Model implements Resource
      * @throws APIException
      * @throws GuzzleException
      */
-    public function addTarget(string $type, LoadBalancerTargetIp $ip = null, bool $usePrivateIp = false, array $labelSelector = [], Server $server = null): ?APIResponse
+    public function addTarget(string $type, ?LoadBalancerTargetIp $ip = null, bool $usePrivateIp = false, array $labelSelector = [], ?Server $server = null): ?APIResponse
     {
         $payload = [
             'type' => $type,
@@ -520,7 +520,7 @@ class LoadBalancer extends Model implements Resource
      * @throws APIException
      * @throws GuzzleException
      */
-    public function removeTarget(string $type, LoadBalancerTargetIp $ip = null, array $labelSelector = null, Server $server = null): ?APIResponse
+    public function removeTarget(string $type, ?LoadBalancerTargetIp $ip = null, ?array $labelSelector = null, ?Server $server = null): ?APIResponse
     {
         $payload = [
             'type' => $type,
@@ -562,7 +562,7 @@ class LoadBalancer extends Model implements Resource
      * @throws APIException
      * @throws GuzzleException
      */
-    public function updateService(int $destinationPort, LoadBalancerHealthCheck $healthCheck, int $listenPort, string $protocol, bool $proxyprotocol, LoadBalancerServiceHttp $http = null): ?APIResponse
+    public function updateService(int $destinationPort, LoadBalancerHealthCheck $healthCheck, int $listenPort, string $protocol, bool $proxyprotocol, ?LoadBalancerServiceHttp $http = null): ?APIResponse
     {
         $payload = [
             'destination_port' => $destinationPort,

--- a/src/Models/LoadBalancers/LoadBalancerRequestOpts.php
+++ b/src/Models/LoadBalancers/LoadBalancerRequestOpts.php
@@ -19,7 +19,7 @@ class LoadBalancerRequestOpts extends RequestOpts
      * @param  $page
      * @param  $labelSelector
      */
-    public function __construct(string $name = null, int $perPage = null, int $page = null, string $labelSelector = null)
+    public function __construct(?string $name = null, ?int $perPage = null, ?int $page = null, ?string $labelSelector = null)
     {
         parent::__construct($perPage, $page, $labelSelector);
         $this->name = $name;

--- a/src/Models/LoadBalancers/LoadBalancers.php
+++ b/src/Models/LoadBalancers/LoadBalancers.php
@@ -29,7 +29,7 @@ class LoadBalancers extends Model implements Resources
      *
      * @throws \LKDev\HetznerCloud\APIException
      */
-    public function all(RequestOpts $requestOpts = null): array
+    public function all(?RequestOpts $requestOpts = null): array
     {
         if ($requestOpts == null) {
             $requestOpts = new LoadBalancerRequestOpts();
@@ -48,7 +48,7 @@ class LoadBalancers extends Model implements Resources
      *
      * @throws \LKDev\HetznerCloud\APIException
      */
-    public function list(RequestOpts $requestOpts = null): ?APIResponse
+    public function list(?RequestOpts $requestOpts = null): ?APIResponse
     {
         if ($requestOpts == null) {
             $requestOpts = new LoadBalancerRequestOpts();

--- a/src/Models/Locations/Location.php
+++ b/src/Models/Locations/Location.php
@@ -75,12 +75,12 @@ class Location extends Model implements Resource
     public function __construct(
         int $id,
         string $name,
-        string $description = null,
-        string $country = null,
-        string $city = null,
-        float $latitude = null,
-        float $longitude = null,
-        string $networkZone = null
+        ?string $description = null,
+        ?string $country = null,
+        ?string $city = null,
+        ?float $latitude = null,
+        ?float $longitude = null,
+        ?string $networkZone = null
     ) {
         $this->id = $id;
         $this->name = $name;

--- a/src/Models/Locations/LocationRequestOpts.php
+++ b/src/Models/Locations/LocationRequestOpts.php
@@ -25,7 +25,7 @@ class LocationRequestOpts extends RequestOpts
      * @param  $page
      * @param  $labelSelector
      */
-    public function __construct(string $name = null, int $perPage = null, int $page = null, string $labelSelector = null)
+    public function __construct(?string $name = null, ?int $perPage = null, ?int $page = null, ?string $labelSelector = null)
     {
         parent::__construct($perPage, $page, $labelSelector);
         $this->name = $name;

--- a/src/Models/Locations/Locations.php
+++ b/src/Models/Locations/Locations.php
@@ -35,7 +35,7 @@ class Locations extends Model implements Resources
      *
      * @throws \LKDev\HetznerCloud\APIException
      */
-    public function all(RequestOpts $requestOpts = null): array
+    public function all(?RequestOpts $requestOpts = null): array
     {
         if ($requestOpts == null) {
             $requestOpts = new LocationRequestOpts();
@@ -54,7 +54,7 @@ class Locations extends Model implements Resources
      *
      * @throws \LKDev\HetznerCloud\APIException
      */
-    public function list(RequestOpts $requestOpts = null): ?APIResponse
+    public function list(?RequestOpts $requestOpts = null): ?APIResponse
     {
         if ($requestOpts == null) {
             $requestOpts = new LocationRequestOpts();

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -17,7 +17,7 @@ abstract class Model
      *
      * @param  Client  $httpClient
      */
-    public function __construct(Client $httpClient = null)
+    public function __construct(?Client $httpClient = null)
     {
         $this->httpClient = $httpClient == null ? HetznerAPIClient::$instance->getHttpClient() : $httpClient;
     }
@@ -36,7 +36,7 @@ abstract class Model
      *
      * @param  Client  $httpClient
      */
-    public function setHttpClient(Client $httpClient = null)
+    public function setHttpClient(?Client $httpClient = null)
     {
         $this->httpClient = $httpClient;
     }

--- a/src/Models/Networks/Network.php
+++ b/src/Models/Networks/Network.php
@@ -73,7 +73,7 @@ class Network extends Model implements Resource
      * @param  int  $id
      * @param  Client|null  $httpClient
      */
-    public function __construct(int $id, Client $httpClient = null)
+    public function __construct(int $id, ?Client $httpClient = null)
     {
         $this->id = $id;
         parent::__construct($httpClient);

--- a/src/Models/Networks/NetworkRequestOpts.php
+++ b/src/Models/Networks/NetworkRequestOpts.php
@@ -23,7 +23,7 @@ class NetworkRequestOpts extends RequestOpts
      * @param  $page
      * @param  $labelSelector
      */
-    public function __construct(string $name = null, int $perPage = null, int $page = null, string $labelSelector = null)
+    public function __construct(?string $name = null, ?int $perPage = null, ?int $page = null, ?string $labelSelector = null)
     {
         $this->name = $name;
         parent::__construct($perPage, $page, $labelSelector);

--- a/src/Models/Networks/Networks.php
+++ b/src/Models/Networks/Networks.php
@@ -32,7 +32,7 @@ class Networks extends Model implements Resources
      *
      * @throws \LKDev\HetznerCloud\APIException
      */
-    public function all(RequestOpts $requestOpts = null): array
+    public function all(?RequestOpts $requestOpts = null): array
     {
         if ($requestOpts == null) {
             $requestOpts = new NetworkRequestOpts();
@@ -51,7 +51,7 @@ class Networks extends Model implements Resources
      *
      * @throws \LKDev\HetznerCloud\APIException
      */
-    public function list(RequestOpts $requestOpts = null): ?APIResponse
+    public function list(?RequestOpts $requestOpts = null): ?APIResponse
     {
         if ($requestOpts == null) {
             $requestOpts = new NetworkRequestOpts();

--- a/src/Models/Networks/Route.php
+++ b/src/Models/Networks/Route.php
@@ -26,7 +26,7 @@ class Route extends Model
      * @param  string  $gateway
      * @param  Client|null  $client
      */
-    public function __construct(string $destination, string $gateway, Client $client = null)
+    public function __construct(string $destination, string $gateway, ?Client $client = null)
     {
         $this->destination = $destination;
         $this->gateway = $gateway;
@@ -38,7 +38,7 @@ class Route extends Model
      * @param  Client|null  $client
      * @return array|Model
      */
-    public static function parse($input, Client $client = null)
+    public static function parse($input, ?Client $client = null)
     {
         return collect($input)->map(function ($route) use ($client) {
             return new self($route->destination, $route->gateway, $client);

--- a/src/Models/Networks/Subnet.php
+++ b/src/Models/Networks/Subnet.php
@@ -38,7 +38,7 @@ class Subnet extends Model
      * @param  string  $gateway
      * @param  Client|null  $client
      */
-    public function __construct(string $type, string $ipRange, string $networkZone, string $gateway = null, Client $client = null)
+    public function __construct(string $type, string $ipRange, string $networkZone, ?string $gateway = null, ?Client $client = null)
     {
         $this->type = $type;
         $this->ipRange = $ipRange;
@@ -52,7 +52,7 @@ class Subnet extends Model
      * @param  Client|null  $client
      * @return array|Model
      */
-    public static function parse($input, Client $client = null)
+    public static function parse($input, ?Client $client = null)
     {
         return collect($input)->map(function ($subnet) use ($client) {
             return new self($subnet->type, $subnet->ip_range, $subnet->network_zone, $subnet->gateway, $client);

--- a/src/Models/Prices/Prices.php
+++ b/src/Models/Prices/Prices.php
@@ -32,7 +32,7 @@ class Prices extends Model
      *
      * @throws \LKDev\HetznerCloud\APIException
      */
-    public function all(RequestOpts $requestOpts = null): ?\stdClass
+    public function all(?RequestOpts $requestOpts = null): ?\stdClass
     {
         if ($requestOpts == null) {
             $requestOpts = new RequestOpts();

--- a/src/Models/PrimaryIps/PrimaryIPRequestOpts.php
+++ b/src/Models/PrimaryIps/PrimaryIPRequestOpts.php
@@ -23,7 +23,7 @@ class PrimaryIPRequestOpts extends RequestOpts
      * @param  $page
      * @param  $labelSelector
      */
-    public function __construct(string $name = null, int $perPage = null, int $page = null, string $labelSelector = null)
+    public function __construct(?string $name = null, ?int $perPage = null, ?int $page = null, ?string $labelSelector = null)
     {
         $this->name = $name;
         parent::__construct($perPage, $page, $labelSelector);

--- a/src/Models/PrimaryIps/PrimaryIp.php
+++ b/src/Models/PrimaryIps/PrimaryIp.php
@@ -235,7 +235,7 @@ class PrimaryIp extends Model implements Resource
      *
      * @throws \LKDev\HetznerCloud\APIException
      */
-    public function changeReverseDNS(string $ip, string $dnsPtr = null): ?APIResponse
+    public function changeReverseDNS(string $ip, ?string $dnsPtr = null): ?APIResponse
     {
         $response = $this->httpClient->post('primary_ips/'.$this->id.'/actions/change_dns_ptr', [
             'json' => [

--- a/src/Models/PrimaryIps/PrimaryIps.php
+++ b/src/Models/PrimaryIps/PrimaryIps.php
@@ -30,7 +30,7 @@ class PrimaryIps extends Model implements Resources
      *
      * @throws \LKDev\HetznerCloud\APIException
      */
-    public function all(RequestOpts $requestOpts = null): array
+    public function all(?RequestOpts $requestOpts = null): array
     {
         if ($requestOpts == null) {
             $requestOpts = new PrimaryIPRequestOpts();
@@ -49,7 +49,7 @@ class PrimaryIps extends Model implements Resources
      *
      * @throws \LKDev\HetznerCloud\APIException
      */
-    public function list(RequestOpts $requestOpts = null): ?APIResponse
+    public function list(?RequestOpts $requestOpts = null): ?APIResponse
     {
         if ($requestOpts == null) {
             $requestOpts = new PrimaryIPRequestOpts();
@@ -124,8 +124,8 @@ class PrimaryIps extends Model implements Resources
         string $name,
         string $assigneeType,
         bool $autoDelete = false,
-        int $assigneeId = null,
-        Datacenter $datacenter = null,
+        ?int $assigneeId = null,
+        ?Datacenter $datacenter = null,
         array $labels = []
     ): ?PrimaryIp {
         $parameters = [

--- a/src/Models/Protection.php
+++ b/src/Models/Protection.php
@@ -27,7 +27,7 @@ class Protection extends Model
      * @param  bool  $delete
      * @param  bool  $rebuild
      */
-    public function __construct(bool $delete, bool $rebuild = null)
+    public function __construct(bool $delete, ?bool $rebuild = null)
     {
         $this->delete = $delete;
         $this->rebuild = $rebuild;

--- a/src/Models/SSHKeys/SSHKeyRequestOpts.php
+++ b/src/Models/SSHKeys/SSHKeyRequestOpts.php
@@ -31,7 +31,7 @@ class SSHKeyRequestOpts extends RequestOpts
      * @param  $page
      * @param  $labelSelector
      */
-    public function __construct(string $name = null, string $fingerprint = null, int $perPage = null, int $page = null, string $labelSelector = null)
+    public function __construct(?string $name = null, ?string $fingerprint = null, ?int $perPage = null, ?int $page = null, ?string $labelSelector = null)
     {
         parent::__construct($perPage, $page, $labelSelector);
         $this->name = $name;

--- a/src/Models/SSHKeys/SSHKeys.php
+++ b/src/Models/SSHKeys/SSHKeys.php
@@ -69,7 +69,7 @@ class SSHKeys extends Model implements Resources
      *
      * @throws \LKDev\HetznerCloud\APIException
      */
-    public function all(RequestOpts $requestOpts = null): array
+    public function all(?RequestOpts $requestOpts = null): array
     {
         if ($requestOpts == null) {
             $requestOpts = new RequestOpts();
@@ -88,7 +88,7 @@ class SSHKeys extends Model implements Resources
      *
      * @throws \LKDev\HetznerCloud\APIException
      */
-    public function list(RequestOpts $requestOpts = null): ?APIResponse
+    public function list(?RequestOpts $requestOpts = null): ?APIResponse
     {
         if ($requestOpts == null) {
             $requestOpts = new RequestOpts();

--- a/src/Models/Servers/Server.php
+++ b/src/Models/Servers/Server.php
@@ -181,7 +181,7 @@ class Server extends Model implements Resource
      * @param  int  $serverId
      * @param  Client|null  $httpClient
      */
-    public function __construct(int $serverId, Client $httpClient = null)
+    public function __construct(int $serverId, ?Client $httpClient = null)
     {
         $this->id = $serverId;
         parent::__construct($httpClient);
@@ -533,7 +533,7 @@ class Server extends Model implements Resource
      *
      * @throws \LKDev\HetznerCloud\APIException
      */
-    public function enableBackups(string $backupWindow = null): ?APIResponse
+    public function enableBackups(?string $backupWindow = null): ?APIResponse
     {
         $response = $this->httpClient->post($this->replaceServerIdInUri('servers/{id}/actions/enable_backup'));
         if (! HetznerAPIClient::hasError($response)) {
@@ -624,7 +624,7 @@ class Server extends Model implements Resource
      *
      * @throws \LKDev\HetznerCloud\APIException
      */
-    public function changeReverseDNS(string $ip, string $dnsPtr = null): ?APIResponse
+    public function changeReverseDNS(string $ip, ?string $dnsPtr = null): ?APIResponse
     {
         $response = $this->httpClient->post($this->replaceServerIdInUri('servers/{id}/actions/change_dns_ptr'), [
             'json' => [
@@ -654,7 +654,7 @@ class Server extends Model implements Resource
      *
      * @throws \LKDev\HetznerCloud\APIException
      */
-    public function metrics(string $type, string $start, string $end, int $step = null)
+    public function metrics(string $type, string $start, string $end, ?int $step = null)
     {
         $response = $this->httpClient->get($this->replaceServerIdInUri('servers/{id}/metrics?').http_build_query(compact('type', 'start', 'end', 'step')));
         if (! HetznerAPIClient::hasError($response)) {
@@ -774,7 +774,7 @@ class Server extends Model implements Resource
      *
      * @throws \LKDev\HetznerCloud\APIException
      */
-    public function attachToNetwork(Network $network, string $ip = null, array $aliasIps = [])
+    public function attachToNetwork(Network $network, ?string $ip = null, array $aliasIps = [])
     {
         $payload = [
             'network' => $network->id,

--- a/src/Models/Servers/ServerRequestOpts.php
+++ b/src/Models/Servers/ServerRequestOpts.php
@@ -28,7 +28,7 @@ class ServerRequestOpts extends RequestOpts
      * @param  $page
      * @param  $labelSelector
      */
-    public function __construct(string $name = null, string $status = null, int $perPage = null, int $page = null, string $labelSelector = null)
+    public function __construct(?string $name = null, ?string $status = null, ?int $perPage = null, ?int $page = null, ?string $labelSelector = null)
     {
         $this->name = $name;
         $this->status = $status;

--- a/src/Models/Servers/Servers.php
+++ b/src/Models/Servers/Servers.php
@@ -39,7 +39,7 @@ class Servers extends Model
      *
      * @throws \LKDev\HetznerCloud\APIException
      */
-    public function all(RequestOpts $requestOpts = null): array
+    public function all(?RequestOpts $requestOpts = null): array
     {
         if ($requestOpts == null) {
             $requestOpts = new ServerRequestOpts();
@@ -58,7 +58,7 @@ class Servers extends Model
      *
      * @throws \LKDev\HetznerCloud\APIException
      */
-    public function list(RequestOpts $requestOpts = null): ?APIResponse
+    public function list(?RequestOpts $requestOpts = null): ?APIResponse
     {
         if ($requestOpts == null) {
             $requestOpts = new ServerRequestOpts();
@@ -161,7 +161,7 @@ class Servers extends Model
         string $name,
         ServerType $serverType,
         Image $image,
-        Datacenter $datacenter = null,
+        ?Datacenter $datacenter = null,
         $ssh_keys = [],
         $startAfterCreate = true,
         $user_data = '',
@@ -233,7 +233,7 @@ class Servers extends Model
     public function createInLocation(string $name,
                                      ServerType $serverType,
                                      Image $image,
-                                     Location $location = null,
+                                     ?Location $location = null,
                                      array $ssh_keys = [],
                                      bool $startAfterCreate = true,
                                      string $user_data = '',

--- a/src/Models/Servers/Types/ServerTypes.php
+++ b/src/Models/Servers/Types/ServerTypes.php
@@ -31,7 +31,7 @@ class ServerTypes extends Model implements Resources
      *
      * @throws \LKDev\HetznerCloud\APIException
      */
-    public function all(RequestOpts $requestOpts = null): array
+    public function all(?RequestOpts $requestOpts = null): array
     {
         if ($requestOpts == null) {
             $requestOpts = new RequestOpts();
@@ -46,7 +46,7 @@ class ServerTypes extends Model implements Resources
      *
      * @throws \LKDev\HetznerCloud\APIException
      */
-    public function list(RequestOpts $requestOpts = null): ?APIResponse
+    public function list(?RequestOpts $requestOpts = null): ?APIResponse
     {
         if ($requestOpts == null) {
             $requestOpts = new RequestOpts();

--- a/src/Models/Servers/Types/ServerTypesRequestOpts.php
+++ b/src/Models/Servers/Types/ServerTypesRequestOpts.php
@@ -23,7 +23,7 @@ class ServerTypesRequestOpts extends RequestOpts
      * @param  $page
      * @param  $labelSelector
      */
-    public function __construct(string $name = null, int $perPage = null, int $page = null, string $labelSelector = null)
+    public function __construct(?string $name = null, ?int $perPage = null, ?int $page = null, ?string $labelSelector = null)
     {
         $this->name = $name;
         parent::__construct($perPage, $page, $labelSelector);

--- a/src/Models/Volumes/Volume.php
+++ b/src/Models/Volumes/Volume.php
@@ -66,7 +66,7 @@ class Volume extends Model implements Resource
      * @param  int  $volumeId
      * @param  Client|null  $httpClient
      */
-    public function __construct(int $volumeId = null, Client $httpClient = null)
+    public function __construct(?int $volumeId = null, ?Client $httpClient = null)
     {
         $this->id = $volumeId;
         parent::__construct($httpClient);

--- a/src/Models/Volumes/VolumeRequestOpts.php
+++ b/src/Models/Volumes/VolumeRequestOpts.php
@@ -31,7 +31,7 @@ class VolumeRequestOpts extends RequestOpts
      * @param  $page
      * @param  $labelSelector
      */
-    public function __construct(string $name = null, string $status = null, int $perPage = null, int $page = null, string $labelSelector = null)
+    public function __construct(?string $name = null, ?string $status = null, ?int $perPage = null, ?int $page = null, ?string $labelSelector = null)
     {
         parent::__construct($perPage, $page, $labelSelector);
         $this->name = $name;

--- a/src/Models/Volumes/Volumes.php
+++ b/src/Models/Volumes/Volumes.php
@@ -41,7 +41,7 @@ class Volumes extends Model implements Resources
      *
      * @throws \LKDev\HetznerCloud\APIException
      */
-    public function all(RequestOpts $requestOpts = null): array
+    public function all(?RequestOpts $requestOpts = null): array
     {
         if ($requestOpts == null) {
             $requestOpts = new RequestOpts();
@@ -60,7 +60,7 @@ class Volumes extends Model implements Resources
      *
      * @throws \LKDev\HetznerCloud\APIException
      */
-    public function list(RequestOpts $requestOpts = null): ?APIResponse
+    public function list(?RequestOpts $requestOpts = null): ?APIResponse
     {
         if ($requestOpts == null) {
             $requestOpts = new VolumeRequestOpts();
@@ -127,7 +127,7 @@ class Volumes extends Model implements Resources
      *
      * @throws \LKDev\HetznerCloud\APIException
      */
-    public function create(string $name, int $size, Server $server = null, Location $location = null, bool $automount = false, string $format = null, array $labels = []): ?APIResponse
+    public function create(string $name, int $size, ?Server $server = null, ?Location $location = null, bool $automount = false, ?string $format = null, array $labels = []): ?APIResponse
     {
         $parameters = [
             'name' => $name,

--- a/src/RequestOpts.php
+++ b/src/RequestOpts.php
@@ -35,7 +35,7 @@ class RequestOpts
      * @param  $page
      * @param  $labelSelector
      */
-    public function __construct(int $perPage = null, int $page = null, string $labelSelector = null)
+    public function __construct(?int $perPage = null, ?int $page = null, ?string $labelSelector = null)
     {
         if ($perPage > HetznerAPIClient::MAX_ENTITIES_PER_PAGE) {
             throw new \InvalidArgumentException('perPage can not be larger than '.HetznerAPIClient::MAX_ENTITIES_PER_PAGE);


### PR DESCRIPTION
Replaces #119 

This PR adds the question mark or null to the parameter types to to avoid the deprecation warning in PHP 8.4.

This was done with the help of laravel/pint and the following configuration in the pint.json:

```json
{
    "preset": "empty",
    "rules": {
        "nullable_type_declaration_for_default_null_value": true
    }
}
```