### PR TITLE
Allow `illuminate/collections:^12.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "php": "^8.1",
     "ext-json": "*",
     "guzzlehttp/guzzle": "^6.3|^7.0",
-    "illuminate/collections": "^5.5|^v6.18|^7.0|^8.0|^9.0|^10.0|^11.0"
+    "illuminate/collections": "^5.5|^v6.18|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^7.0|^8.5.5|^9.0",


### PR DESCRIPTION
Currently when installing this package in a Laravel 12 application it pulls in an older version which still uses `tightenco/collect`. These changes allow installing the latest version on Laravel 12.