### PR TITLE
fix(lb): allow null for "deprecated" field of lb type

### DIFF
--- a/src/Models/LoadBalancerTypes/LoadBalancerType.php
+++ b/src/Models/LoadBalancerTypes/LoadBalancerType.php
@@ -20,7 +20,7 @@ class LoadBalancerType extends Model implements Resource
     public $name;
 
     /**
-     * @var string
+     * @var string|null
      */
     public $deprecated;
 
@@ -57,7 +57,7 @@ class LoadBalancerType extends Model implements Resource
     /**
      * @param  int  $id
      * @param  string  $name
-     * @param  string  $deprecated
+     * @param  string|null  $deprecated
      * @param  string  $description
      * @param  int  $max_assigned_certificates
      * @param  int  $max_connections
@@ -65,7 +65,7 @@ class LoadBalancerType extends Model implements Resource
      * @param  int  $max_targets
      * @param  array|\LKDev\HetznerCloud\Models\Prices\Prices  $prices
      */
-    public function __construct(int $id, string $name, string $deprecated, string $description, int $max_assigned_certificates, int $max_connections, int $max_services, int $max_targets, $prices)
+    public function __construct(int $id, string $name, ?string $deprecated, string $description, int $max_assigned_certificates, int $max_connections, int $max_services, int $max_targets, $prices)
     {
         $this->id = $id;
         $this->name = $name;

--- a/tests/Unit/Models/LoadBalancerTypes/LoadBalancerTypesTest.php
+++ b/tests/Unit/Models/LoadBalancerTypes/LoadBalancerTypesTest.php
@@ -27,7 +27,7 @@ class LoadBalancerTypesTest extends TestCase
         $this->mockHandler->append(new Response(200, [], file_get_contents(__DIR__.'/fixtures/loadBalancerTypes.json')));
         $loadBalancerTypes = $this->load_balancer_types->all();
 
-        $this->assertCount(1, $loadBalancerTypes);
+        $this->assertCount(2, $loadBalancerTypes);
         $this->assertLastRequestEquals('GET', '/load_balancer_types');
     }
 
@@ -58,7 +58,7 @@ class LoadBalancerTypesTest extends TestCase
         $this->mockHandler->append(new Response(200, [], file_get_contents(__DIR__.'/fixtures/loadBalancerTypes.json')));
         $loadBalancerTypes = $this->load_balancer_types->list()->load_balancer_types;
 
-        $this->assertEquals(count($loadBalancerTypes), 1);
+        $this->assertEquals(count($loadBalancerTypes), 2);
         $this->assertEquals($loadBalancerTypes[0]->id, 4711);
         $this->assertEquals($loadBalancerTypes[0]->name, 'lb11');
         $this->assertLastRequestEquals('GET', '/load_balancer_types');

--- a/tests/Unit/Models/LoadBalancerTypes/fixtures/loadBalancerTypes.json
+++ b/tests/Unit/Models/LoadBalancerTypes/fixtures/loadBalancerTypes.json
@@ -22,6 +22,29 @@
 					}
 				}
 			]
+		},
+		{
+			"deprecated": null,
+			"description": "LB11",
+			"id": 1174,
+			"max_assigned_certificates": 10,
+			"max_connections": 20000,
+			"max_services": 15,
+			"max_targets": 75,
+			"name": "lb21",
+			"prices": [
+				{
+					"location": "fsn1",
+					"price_hourly": {
+						"gross": "1.1900000000000000",
+						"net": "1.0000000000"
+					},
+					"price_monthly": {
+						"gross": "1.1900000000000000",
+						"net": "1.0000000000"
+					}
+				}
+			]
 		}
 	],
 	"meta": {


### PR DESCRIPTION
This PR addresses #108 by allowing `null` for the `deprecated` parameter of a loadbalancer type.

@LKaemmerling this is kind of urgent as this error currently mostly prevents usage of the loadbalancer part of this sdk. Please LMK if you wish to have any additional changes applied (or feel free to add them yourself)