### PR TITLE
Refactor GuzzleClient

### DIFF
--- a/src/Clients/GuzzleClient.php
+++ b/src/Clients/GuzzleClient.php
@@ -10,17 +10,17 @@ class GuzzleClient
     protected Client $client;
 
     /**
-     * @param HetznerAPIClient $client
-     * @param array $additionalGuzzleConfig
+     * @param  HetznerAPIClient  $client
+     * @param  array  $additionalGuzzleConfig
      */
     public function __construct(HetznerAPIClient $client, $additionalGuzzleConfig = [])
     {
         $guzzleConfig = array_merge([
             'base_uri' => $client->getBaseUrl(),
             'headers' => [
-                'Authorization' => 'Bearer ' . $client->getApiToken(),
+                'Authorization' => 'Bearer '.$client->getApiToken(),
                 'Content-Type' => 'application/json',
-                'User-Agent' => ((strlen($client->getUserAgent()) > 0) ? $client->getUserAgent() . ' ' : '') . 'hcloud-php/' . HetznerAPIClient::VERSION,
+                'User-Agent' => ((strlen($client->getUserAgent()) > 0) ? $client->getUserAgent().' ' : '').'hcloud-php/'.HetznerAPIClient::VERSION,
             ],
         ], $additionalGuzzleConfig);
         $this->client = new Client($guzzleConfig);

--- a/src/Clients/GuzzleClient.php
+++ b/src/Clients/GuzzleClient.php
@@ -5,22 +5,29 @@ namespace LKDev\HetznerCloud\Clients;
 use GuzzleHttp\Client;
 use LKDev\HetznerCloud\HetznerAPIClient;
 
-class GuzzleClient extends Client
+class GuzzleClient
 {
+    protected Client $client;
+
     /**
-     * @param  HetznerAPIClient  $client
-     * @param  array  $additionalGuzzleConfig
+     * @param HetznerAPIClient $client
+     * @param array $additionalGuzzleConfig
      */
     public function __construct(HetznerAPIClient $client, $additionalGuzzleConfig = [])
     {
         $guzzleConfig = array_merge([
             'base_uri' => $client->getBaseUrl(),
             'headers' => [
-                'Authorization' => 'Bearer '.$client->getApiToken(),
+                'Authorization' => 'Bearer ' . $client->getApiToken(),
                 'Content-Type' => 'application/json',
-                'User-Agent' => ((strlen($client->getUserAgent()) > 0) ? $client->getUserAgent().' ' : '').'hcloud-php/'.HetznerAPIClient::VERSION,
+                'User-Agent' => ((strlen($client->getUserAgent()) > 0) ? $client->getUserAgent() . ' ' : '') . 'hcloud-php/' . HetznerAPIClient::VERSION,
             ],
         ], $additionalGuzzleConfig);
-        parent::__construct($guzzleConfig);
+        $this->client = new Client($guzzleConfig);
+    }
+
+    public function __call($name, $arguments)
+    {
+        return $this->client->$name(...$arguments);
     }
 }

--- a/src/Models/PlacementGroups/PlacementGroup.php
+++ b/src/Models/PlacementGroups/PlacementGroup.php
@@ -2,6 +2,7 @@
 
 namespace LKDev\HetznerCloud\Models\PlacementGroups;
 
+use GuzzleHttp\Client;
 use LKDev\HetznerCloud\APIResponse;
 use LKDev\HetznerCloud\HetznerAPIClient;
 use LKDev\HetznerCloud\Models\Actions\Action;


### PR DESCRIPTION
The underlying GuzzleClient is marked as final since now around 5 years. Actually i completely missed that and therefore our GuzzleClient broke phpstan. The "new" GuzzleClient nolonger extends the old one. It is now simply a wrapper (passing call calls to the GuzzleClient)