### PR TITLE
Fixing `Client` return type

### DIFF
--- a/src/HetznerAPIClient.php
+++ b/src/HetznerAPIClient.php
@@ -125,7 +125,7 @@ class HetznerAPIClient
     /**
      * @return Client
      */
-    public function getHttpClient(): Client
+    public function getHttpClient(): GuzzleClient
     {
         return $this->httpClient;
     }


### PR DESCRIPTION
Closes https://github.com/LKDevelopment/hetzner-cloud-php-sdk/issues/130