### PR TITLE
  fix: public_net parsing error & add deprecation/locationAvailability to ServerType

### DIFF
--- a/src/Models/Servers/Servers.php
+++ b/src/Models/Servers/Servers.php
@@ -174,7 +174,7 @@ class Servers extends Model
         $networks = [],
         array $labels = [],
         array $firewalls = [],
-        array $public_net = [],
+        ?array $public_net = null,
         ?int $placement_group = null
     ): ?APIResponse {
         $parameters = [
@@ -188,7 +188,6 @@ class Servers extends Model
             'volumes' => $volumes,
             'automount' => $automount,
             'networks' => $networks,
-            'public_net' => $public_net,
         ];
         if (! empty($labels)) {
             $parameters['labels'] = $labels;
@@ -198,6 +197,9 @@ class Servers extends Model
         }
         if ($placement_group != null) {
             $parameters['placement_group'] = $placement_group;
+        }
+        if ($public_net != null) {
+            $parameters['public_net'] = $public_net;
         }
         $response = $this->httpClient->post('servers', [
             'json' => $parameters,
@@ -252,7 +254,7 @@ class Servers extends Model
                                      array $networks = [],
                                      array $labels = [],
                                      array $firewalls = [],
-                                     array $public_net = [],
+                                     ?array $public_net = null,
                                      ?int $placement_group = null
     ): ?APIResponse {
         $parameters = [
@@ -266,7 +268,6 @@ class Servers extends Model
             'volumes' => $volumes,
             'automount' => $automount,
             'networks' => $networks,
-            'public_net' => $public_net,
         ];
         if (! empty($labels)) {
             $parameters['labels'] = $labels;
@@ -276,6 +277,9 @@ class Servers extends Model
         }
         if ($placement_group != null) {
             $parameters['placement_group'] = $placement_group;
+        }
+        if ($public_net != null) {
+            $parameters['public_net'] = $public_net;
         }
         $response = $this->httpClient->post('servers', [
             'json' => $parameters,

--- a/src/Models/Servers/Types/ServerType.php
+++ b/src/Models/Servers/Types/ServerType.php
@@ -107,11 +107,11 @@ class ServerType extends Model
         $this->cpuType = $input->cpu_type ?? null;
         $this->architecture = property_exists($input, 'architecture') ? $input->architecture : null;
         $this->deprecation = (property_exists($input, 'deprecation') && $input->deprecation !== null) ? (array) $input->deprecation : null;
-        $this->locationAvailability = collect($input->locations ?? [])
-            ->mapWithKeys(fn ($loc): array => [
-                $loc->name => ($loc->deprecation !== null) ? (array) $loc->deprecation : null,
-            ])
-            ->all();
+        $locationAvailability = [];
+        foreach ($input->locations ?? [] as $loc) {
+            $locationAvailability[$loc->name] = ($loc->deprecation !== null) ? (array) $loc->deprecation : null;
+        }
+        $this->locationAvailability = $locationAvailability;
 
         return $this;
     }

--- a/src/Models/Servers/Types/ServerType.php
+++ b/src/Models/Servers/Types/ServerType.php
@@ -71,6 +71,14 @@ class ServerType extends Model
     public $deprecation;
 
     /**
+     * Per-location availability info, keyed by location name.
+     * Each entry contains a deprecation object or null if still available.
+     *
+     * @var array<string, array{announced: string, unavailable_after: string}|null>
+     */
+    public $locationAvailability = [];
+
+    /**
      * ServerType constructor.
      *
      * @param  int  $serverTypeId
@@ -99,6 +107,11 @@ class ServerType extends Model
         $this->cpuType = $input->cpu_type ?? null;
         $this->architecture = property_exists($input, 'architecture') ? $input->architecture : null;
         $this->deprecation = (property_exists($input, 'deprecation') && $input->deprecation !== null) ? (array) $input->deprecation : null;
+        $this->locationAvailability = collect($input->locations ?? [])
+            ->mapWithKeys(fn ($loc): array => [
+                $loc->name => ($loc->deprecation !== null) ? (array) $loc->deprecation : null,
+            ])
+            ->all();
 
         return $this;
     }

--- a/src/Models/Servers/Types/ServerType.php
+++ b/src/Models/Servers/Types/ServerType.php
@@ -64,6 +64,13 @@ class ServerType extends Model
     public $architecture;
 
     /**
+     * Deprecation info if the server type is deprecated, null otherwise.
+     *
+     * @var array{announced: string, unavailable_after: string}|null
+     */
+    public $deprecation;
+
+    /**
      * ServerType constructor.
      *
      * @param  int  $serverTypeId
@@ -91,6 +98,7 @@ class ServerType extends Model
         $this->storageType = $input->storage_type ?? null;
         $this->cpuType = $input->cpu_type ?? null;
         $this->architecture = property_exists($input, 'architecture') ? $input->architecture : null;
+        $this->deprecation = property_exists($input, 'deprecation') ? (array) $input->deprecation : null;
 
         return $this;
     }

--- a/src/Models/Servers/Types/ServerType.php
+++ b/src/Models/Servers/Types/ServerType.php
@@ -98,7 +98,7 @@ class ServerType extends Model
         $this->storageType = $input->storage_type ?? null;
         $this->cpuType = $input->cpu_type ?? null;
         $this->architecture = property_exists($input, 'architecture') ? $input->architecture : null;
-        $this->deprecation = property_exists($input, 'deprecation') ? (array) $input->deprecation : null;
+        $this->deprecation = (property_exists($input, 'deprecation') && $input->deprecation !== null) ? (array) $input->deprecation : null;
 
         return $this;
     }


### PR DESCRIPTION
Description:                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                
Bugfixes
                                                                                                                                                                                                                                                                                
public_net JSON parse error                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                
Fixes a server creation failure where the API rejected the public_net parameter with:                                                                                                                                                                                           
failed to parse json: cannot parse type array as createServerPublicNet
The public_net parameter is now optional and handled correctly.                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                
New Features                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                
ServerType::$deprecation                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                
Maps the top-level deprecation object from the Hetzner API onto ServerType. Previously this field was not available in the model, making it impossible to detect globally deprecated server types.                                                                              
                                                          
▎ Bugfix included: (array) null evaluates to [] not null, so an explicit !== null guard was added before casting.                                                                                                                                                               
                                                          
ServerType::$locationAvailability                                                                                                                                                                                                                                               
                                                          
Hetzner deprecates server types not only globally but also per location via a nested locations array in the API response. This new field maps location name → deprecation info (null = still bookable), enabling consumers to filter out unavailable types per location.        
 
// Example: filter out types deprecated in a specific location                                                                                                                                                                                                                  
$type->locationAvailability['fsn1'] === null // true = still bookable 