### PR TITLE
Fix Image Parsing Between Object And Array

### DIFF
--- a/src/Models/Images/Image.php
+++ b/src/Models/Images/Image.php
@@ -135,7 +135,7 @@ class Image extends Model implements Resource
     public $protection;
 
     /**
-     * @var array
+     * @var \stdClass|null
      */
     public $labels;
 
@@ -158,21 +158,21 @@ class Image extends Model implements Resource
      * Image constructor.
      *
      * @param  int  $id
-     * @param  string  $type
-     * @param  string  $status
-     * @param  string  $name
-     * @param  string  $description
-     * @param  float  $imageSize
-     * @param  int  $diskSize
-     * @param  string  $created
-     * @param  \LKDev\HetznerCloud\Models\Servers\Server  $createdFrom
-     * @param  int  $boundTo
-     * @param  string  $osFlavor
-     * @param  string  $osVersion
+     * @param  string|null  $type
+     * @param  string|null  $status
+     * @param  string|null  $name
+     * @param  string|null  $description
+     * @param  float|null  $imageSize
+     * @param  int|null  $diskSize
+     * @param  string|null  $created
+     * @param  null  $createdFrom
+     * @param  int|null  $boundTo
+     * @param  string|null  $osFlavor
+     * @param  string|null  $osVersion
      * @param  bool  $rapidDeploy
-     * @param  Protection  $protection
-     * @param  string  $architecture
-     * @param  array  $labels
+     * @param  Protection|null  $protection
+     * @param  string|null  $architecture
+     * @param  \stdClass  $labels
      * @param  string|null  $deleted
      * @param  string|null  $deprecated
      */
@@ -192,7 +192,7 @@ class Image extends Model implements Resource
         ?bool $rapidDeploy = null,
         ?Protection $protection = null,
         ?string $architecture = null,
-        array $labels = [],
+        \stdClass $labels = new \stdClass(),
         ?string $deleted = null,
         ?string $deprecated = null
     ) {
@@ -293,7 +293,7 @@ class Image extends Model implements Resource
 
     /**
      * @param  $input
-     * @return \LKDev\HetznerCloud\Models\Images\Image|static
+     * @return \LKDev\HetznerCloud\Models\Images\Image|static|null
      */
     public static function parse($input): ?Image
     {
@@ -301,7 +301,7 @@ class Image extends Model implements Resource
             return null;
         }
 
-        return new self($input->id, $input->type, $input->status, $input->name, $input->description, $input->image_size, $input->disk_size, $input->created, $input->created_from, $input->bound_to, $input->os_flavor, $input->os_version, $input->rapid_deploy, Protection::parse($input->protection), $input->architecture ?? null, get_object_vars($input->labels), $input->deleted ?? null, $input->deprecated ?? null);
+        return new self($input->id, $input->type, $input->status, $input->name, $input->description, $input->image_size, $input->disk_size, $input->created, $input->created_from, $input->bound_to, $input->os_flavor, $input->os_version, $input->rapid_deploy, Protection::parse($input->protection), $input->architecture ?? null, $input->labels, $input->deleted ?? null, $input->deprecated ?? null);
     }
 
     public function reload()

--- a/tests/Unit/Models/Images/ImagesTest.php
+++ b/tests/Unit/Models/Images/ImagesTest.php
@@ -33,7 +33,7 @@ class ImagesTest extends TestCase
         $this->assertEquals($image->id, 4711);
         $this->assertEquals($image->name, 'ubuntu-20.04');
 
-        $this->assertEmpty($image->labels);
+        $this->assertEmpty((array) $image->labels);
 
         $this->assertLastRequestEquals('GET', '/images/4711');
     }
@@ -45,7 +45,7 @@ class ImagesTest extends TestCase
         $this->assertEquals($image->id, 4711);
         $this->assertEquals($image->name, 'ubuntu-20.04');
 
-        $this->assertEmpty($image->labels);
+        $this->assertEmpty((array) $image->labels);
         $this->assertLastRequestEquals('GET', '/images');
         $this->assertLastRequestQueryParametersContains('name', 'ubuntu-20.04');
     }
@@ -57,7 +57,7 @@ class ImagesTest extends TestCase
         $this->assertEquals($image->id, 4711);
         $this->assertEquals($image->name, 'ubuntu-20.04');
 
-        $this->assertEmpty($image->labels);
+        $this->assertEmpty((array) $image->labels);
         $this->assertLastRequestEquals('GET', '/images');
         $this->assertLastRequestQueryParametersContains('name', 'ubuntu-20.04');
         $this->assertLastRequestQueryParametersContains('architecture', 'arm');


### PR DESCRIPTION
The default value for Image::labels is an array, according to the API, an object is returned, however.